### PR TITLE
docs: Add AUR installation instructions for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ brew install difi
 go install github.com/oug-t/difi/cmd/difi@latest
 ```
 
+#### AUR (Arch Linux)
+
+**Binary (pre-built):**
+```bash
+pikaur -S difi-bin
+```
+
+**Build from source:**
+```bash
+pikaur -S difi
+```
+
 #### Manual (Linux / Windows)
 
 - Download the binary from Releases and add it to your `$PATH`.


### PR DESCRIPTION
The README currently lacks installation instructions for Arch Linux users, who represent a significant portion of the Linux community. This forces Arch users to either build manually from source or use the generic Go install method, both of which bypass the benefits of package management (dependency tracking, easy updates, and system integration).

Add AUR installation instructions offering both pre-built binary and source-based options. This aligns with the existing package manager approach used for macOS (Homebrew) and provides Arch users with a native installation path that integrates with their system's package management workflow.

Fixes # (issue)

## Type of change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update

## Checklist:
- [ ] My code follows the style guidelines of this project (`go fmt ./...`)
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
