### PR TITLE
fix(ui): resolve status bar background color erase in tmux

### DIFF
--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -277,8 +277,18 @@ func (m Model) renderTopBar() string {
 }
 
 func (m Model) viewStatusBar() string {
-	shortcuts := StatusKeyStyle.Render("? Help  q Quit  Tab Switch  V Visual")
-	return StatusBarStyle.Width(m.width).Render(shortcuts)
+	shortcutsStyle := StatusKeyStyle.Copy().Background(nord0)
+	shortcuts := shortcutsStyle.Render("? Help  q Quit  Tab Switch  V Visual")
+
+	availWidth := m.width - lipgloss.Width(shortcuts)
+	if availWidth < 0 {
+		availWidth = 0
+	}
+
+	paddingStyle := lipgloss.NewStyle().Background(nord0)
+	padding := paddingStyle.Render(strings.Repeat(" ", availWidth))
+
+	return lipgloss.JoinHorizontal(lipgloss.Top, shortcuts, padding)
 }
 
 func (m Model) renderHelpDrawer() string {


### PR DESCRIPTION
The status bar previously relied on lipgloss auto-padding to fill In
multiplexers like tmux, the text's internal ANSI reset code caused a
Background Color Erase bug, leaving a vertical gap where the
background color dropped out.

This replaces the auto-padding with an explicit width calculation.
