### PR TITLE
feat(ui): add GitHub-style side-by-side split diff view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 # OS
 .DS_Store
 /difi
+
+# mise project-local Go caches (see .mise.toml)
+.go/

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ git diff | difi
 | `j / k`       | Move cursor down / up                        |
 | `h / l`       | Focus Left (Tree) / Focus Right (Diff)       |
 | `e` / `Enter` | Edit file (opens editor at selected line)    |
+| `s`           | Toggle split / unified diff view             |
 | `:`           | Open vim-style command line                  |
 | `?`           | Toggle help drawer                           |
 | `q` / `ZZ`    | Quit                                         |
@@ -121,6 +122,7 @@ ui:
 | `editor`          | `$DIFI_EDITOR`, `$EDITOR`, `$VISUAL`, or `vi` | The editor to open when pressing `e` on a file.          |
 | `ui.line_numbers` | `"hybrid"`                                    | The style of line numbers in the diff view.              |
 | `ui.theme`        | `"nord"`                                      | The vim colorscheme used for syntax highlighting and UI. |
+| `ui.diff_mode`    | `"unified"`                                   | Diff layout: `"unified"` or `"split"` (side-by-side).    |
 | `ui.diff_add_bg`  | `""`                                          | Hex code or terminal color for added line backgrounds.   |
 | `ui.diff_del_bg`  | `""`                                          | Hex code or terminal color for deleted line backgrounds. |
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 type UIConfig struct {
 	LineNumbers string `yaml:"line_numbers"`
 	Theme       string `yaml:"theme"`
+	DiffMode    string `yaml:"diff_mode"`
 	DiffAddBg   string `yaml:"diff_add_bg"`
 	DiffDelBg   string `yaml:"diff_del_bg"`
 }
@@ -24,6 +25,7 @@ func Load() Config {
 		UI: UIConfig{
 			LineNumbers: "hybrid",
 			Theme:       "nord",
+			DiffMode:    "unified",
 		},
 	}
 
@@ -45,6 +47,10 @@ func Load() Config {
 	}
 	if cfg.Editor == "" {
 		cfg.Editor = "vi"
+	}
+
+	if cfg.UI.DiffMode == "" {
+		cfg.UI.DiffMode = "unified"
 	}
 
 	return cfg

--- a/internal/diffsplit/split.go
+++ b/internal/diffsplit/split.go
@@ -1,0 +1,175 @@
+package diffsplit
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var hunkHeaderRe = regexp.MustCompile(`^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@`)
+
+// LineKind describes the role of a side in a split row.
+type LineKind int
+
+const (
+	KindEmpty LineKind = iota
+	KindContext
+	KindAdd
+	KindDel
+)
+
+// Side is one column cell in a split diff row.
+type Side struct {
+	RawIdx      int
+	Content     string
+	Highlighted string
+	Kind        LineKind
+	LineNo      int // source file line number, 0 when empty
+}
+
+// Row is a GitHub-style split diff row with optional left and right content.
+type Row struct {
+	Left  Side
+	Right Side
+}
+
+type pendingLine struct {
+	rawIdx      int
+	content     string
+	highlighted string
+	kind        LineKind
+}
+
+// Build converts unified diff display lines into side-by-side rows.
+// diffLines and highlighted must have the same length; only hunk content
+// lines (context, additions, deletions) are included.
+func Build(diffLines, highlighted []string) []Row {
+	var rows []Row
+	var dels, adds []pendingLine
+	oldLine, newLine := 0, 0
+	inHunk := false
+
+	flush := func() {
+		n := len(dels)
+		if len(adds) > n {
+			n = len(adds)
+		}
+		for i := 0; i < n; i++ {
+			var row Row
+			if i < len(dels) {
+				row.Left = sideFromPending(dels[i], oldLine)
+				oldLine++
+			}
+			if i < len(adds) {
+				row.Right = sideFromPending(adds[i], newLine)
+				newLine++
+			}
+			rows = append(rows, row)
+		}
+		dels = dels[:0]
+		adds = adds[:0]
+	}
+
+	for i, raw := range diffLines {
+		clean := strings.TrimRight(stripAnsi(raw), "\r")
+		hl := ""
+		if i < len(highlighted) {
+			hl = highlighted[i]
+		}
+
+		if m := hunkHeaderRe.FindStringSubmatch(clean); len(m) > 2 {
+			flush()
+			oldStart, _ := strconv.Atoi(m[1])
+			newStart, _ := strconv.Atoi(m[2])
+			if oldStart < 1 {
+				oldStart = 1
+			}
+			if newStart < 1 {
+				newStart = 1
+			}
+			oldLine = oldStart
+			newLine = newStart
+			inHunk = true
+			continue
+		}
+
+		if !inHunk {
+			continue
+		}
+
+		isAdd := strings.HasPrefix(clean, "+") && !strings.HasPrefix(clean, "+++")
+		isDel := strings.HasPrefix(clean, "-") && !strings.HasPrefix(clean, "---")
+		isCtx := strings.HasPrefix(clean, " ")
+
+		if !isAdd && !isDel && !isCtx {
+			continue
+		}
+
+		content := clean
+		if len(content) > 0 {
+			content = content[1:]
+		}
+
+		pl := pendingLine{
+			rawIdx:      i,
+			content:     content,
+			highlighted: hl,
+		}
+
+		switch {
+		case isCtx:
+			flush()
+			rows = append(rows, Row{
+				Left:  sideFromPending(pendingLine{rawIdx: i, content: content, highlighted: hl, kind: KindContext}, oldLine),
+				Right: sideFromPending(pendingLine{rawIdx: i, content: content, highlighted: hl, kind: KindContext}, newLine),
+			})
+			oldLine++
+			newLine++
+		case isDel:
+			pl.kind = KindDel
+			dels = append(dels, pl)
+		case isAdd:
+			pl.kind = KindAdd
+			adds = append(adds, pl)
+		}
+	}
+
+	flush()
+	return rows
+}
+
+func sideFromPending(pl pendingLine, lineNo int) Side {
+	if pl.kind == KindEmpty && pl.rawIdx < 0 {
+		return Side{Kind: KindEmpty}
+	}
+	return Side{
+		RawIdx:      pl.rawIdx,
+		Content:     pl.content,
+		Highlighted: pl.highlighted,
+		Kind:        pl.kind,
+		LineNo:      lineNo,
+	}
+}
+
+// PrimaryRawIdx returns the diff line index used for editor line mapping.
+// Prefer the right side when present (context/add), otherwise the left.
+func (r Row) PrimaryRawIdx() int {
+	if r.Right.Kind != KindEmpty && r.Right.RawIdx >= 0 {
+		return r.Right.RawIdx
+	}
+	if r.Left.RawIdx >= 0 {
+		return r.Left.RawIdx
+	}
+	return 0
+}
+
+// IsNavigable reports whether a row should receive cursor focus.
+func (r Row) IsNavigable() bool {
+	return r.Left.Kind != KindEmpty || r.Right.Kind != KindEmpty
+}
+
+var ansiRe = regexp.MustCompile("[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))")
+
+func stripAnsi(str string) string {
+	return ansiRe.ReplaceAllString(str, "")
+}

--- a/internal/diffsplit/split_git_test.go
+++ b/internal/diffsplit/split_git_test.go
@@ -1,0 +1,19 @@
+package diffsplit
+
+import "testing"
+
+func TestBuild_gitHunkHeaderWithContext(t *testing.T) {
+	diffLines := []string{
+		"@@ -10,4 +10,5 @@ func main() {",
+		" func main() {",
+		`-	fmt.Println("old")`,
+		`+	fmt.Println("new")`,
+		" }",
+	}
+	highlighted := make([]string, len(diffLines))
+
+	rows := Build(diffLines, highlighted)
+	if len(rows) == 0 {
+		t.Fatal("expected rows from git-style hunk header with trailing context")
+	}
+}

--- a/internal/diffsplit/split_test.go
+++ b/internal/diffsplit/split_test.go
@@ -1,0 +1,110 @@
+package diffsplit
+
+import "testing"
+
+func TestBuild_contextAndChanges(t *testing.T) {
+	diffLines := []string{
+		"@@ -10,4 +10,5 @@",
+		" func main() {",
+		`-	fmt.Println("old")`,
+		`+	fmt.Println("new")`,
+		`+	fmt.Println("added")`,
+		" }",
+	}
+	highlighted := []string{
+		"@@ -10,4 +10,5 @@",
+		"func main() {",
+		`fmt.Println("old")`,
+		`fmt.Println("new")`,
+		`fmt.Println("added")`,
+		"}",
+	}
+
+	rows := Build(diffLines, highlighted)
+	if len(rows) != 4 {
+		t.Fatalf("got %d rows, want 4", len(rows))
+	}
+
+	// Context row
+	if rows[0].Left.Kind != KindContext || rows[0].Right.Kind != KindContext {
+		t.Errorf("row 0: want context on both sides")
+	}
+	if rows[0].Left.LineNo != 10 || rows[0].Right.LineNo != 10 {
+		t.Errorf("row 0: line numbers = %d/%d, want 10/10", rows[0].Left.LineNo, rows[0].Right.LineNo)
+	}
+
+	// Paired change: deletion left, addition right
+	if rows[1].Left.Kind != KindDel || rows[1].Right.Kind != KindAdd {
+		t.Errorf("row 1: want del/add pair, got %v/%v", rows[1].Left.Kind, rows[1].Right.Kind)
+	}
+	if rows[1].Left.Content != "\tfmt.Println(\"old\")" {
+		t.Errorf("row 1 left content = %q", rows[1].Left.Content)
+	}
+	if rows[1].Right.Content != "\tfmt.Println(\"new\")" {
+		t.Errorf("row 1 right content = %q", rows[1].Right.Content)
+	}
+
+	// Pure addition on right
+	if rows[2].Left.Kind != KindEmpty || rows[2].Right.Kind != KindAdd {
+		t.Errorf("row 2: want empty/add, got %v/%v", rows[2].Left.Kind, rows[2].Right.Kind)
+	}
+	if rows[2].Right.LineNo != 12 {
+		t.Errorf("row 2 right line = %d, want 12", rows[2].Right.LineNo)
+	}
+
+	// Trailing context
+	if rows[3].Left.LineNo != 12 || rows[3].Right.LineNo != 13 {
+		t.Errorf("row 3 line numbers = %d/%d, want 12/13", rows[3].Left.LineNo, rows[3].Right.LineNo)
+	}
+}
+
+func TestBuild_pureDeletion(t *testing.T) {
+	diffLines := []string{
+		"@@ -1,2 +1,1 @@",
+		"-removed",
+		" context",
+	}
+	highlighted := []string{"@@", "removed", "context"}
+
+	rows := Build(diffLines, highlighted)
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2", len(rows))
+	}
+	if rows[0].Left.Kind != KindDel || rows[0].Right.Kind != KindEmpty {
+		t.Errorf("row 0: want del/empty")
+	}
+	if rows[1].Left.Kind != KindContext {
+		t.Errorf("row 1: want left context")
+	}
+}
+
+func TestBuild_pureAddition(t *testing.T) {
+	diffLines := []string{
+		"@@ -0,0 +1,1 @@",
+		"+added",
+	}
+	highlighted := []string{"@@", "added"}
+
+	rows := Build(diffLines, highlighted)
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	if rows[0].Left.Kind != KindEmpty || rows[0].Right.Kind != KindAdd {
+		t.Errorf("row 0: want empty/add")
+	}
+}
+
+func TestRow_PrimaryRawIdx(t *testing.T) {
+	row := Row{
+		Left:  Side{RawIdx: 5, Kind: KindDel},
+		Right: Side{RawIdx: 6, Kind: KindAdd},
+	}
+	if row.PrimaryRawIdx() != 6 {
+		t.Errorf("PrimaryRawIdx() = %d, want 6", row.PrimaryRawIdx())
+	}
+
+	row = Row{Left: Side{RawIdx: 5, Kind: KindDel}}
+	if row.PrimaryRawIdx() != 5 {
+		t.Errorf("PrimaryRawIdx() for del-only = %d, want 5", row.PrimaryRawIdx())
+	}
+}

--- a/internal/hg/client_test.go
+++ b/internal/hg/client_test.go
@@ -68,7 +68,7 @@ func TestCalculateFileLine(t *testing.T) {
 		{
 			name:            "hunk header",
 			visualLineIndex: 3,
-			expectedLineNo:  9,
+			expectedLineNo:  10,
 		},
 		{
 			name:            "context line",
@@ -78,7 +78,7 @@ func TestCalculateFileLine(t *testing.T) {
 		{
 			name:            "deleted line",
 			visualLineIndex: 5,
-			expectedLineNo:  10,
+			expectedLineNo:  11,
 		},
 		{
 			name:            "added line 1",
@@ -92,9 +92,11 @@ func TestCalculateFileLine(t *testing.T) {
 		},
 	}
 
+	diffLines := strings.Split(diffContent, "\n")
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := CalculateFileLine(diffContent, tt.visualLineIndex)
+			result := CalculateFileLine(diffLines, tt.visualLineIndex)
 			if result != tt.expectedLineNo {
 				t.Errorf("CalculateFileLine(%d) = %d, want %d", tt.visualLineIndex, result, tt.expectedLineNo)
 			}

--- a/internal/ui/help.txt
+++ b/internal/ui/help.txt
@@ -72,6 +72,24 @@ Set a custom editor in ~/.config/difi/config.yaml:
     editor: "nvim"
 
 ────────────────────────────────────────────────────────────────────────────
+Diff Layout                                             *difi-diff-layout*
+────────────────────────────────────────────────────────────────────────────
+
+difi supports two diff layouts:
+
+unified (default)        single column with + / - prefixes
+split                    GitHub-style side-by-side (old left, new right)
+
+s                        toggle split / unified (works from either pane)
+:set split               switch to split layout
+:set unified             switch to unified layout
+
+Set the default in ~/.config/difi/config.yaml:
+
+    ui:
+      diff_mode: "split"
+
+────────────────────────────────────────────────────────────────────────────
 Visual Mode                                             *difi-visual-mode*
 ────────────────────────────────────────────────────────────────────────────
 
@@ -113,6 +131,8 @@ Press : to open a vim-style command line at the bottom of the screen.
 :set relative             relative mode
 :set absolute             absolute mode
 :set hidden               no line numbers
+:set split                side-by-side diff (GitHub-style)
+:set unified              unified diff (default)
 
 Press Tab to cycle through matching command names, theme names, and :set
 option values. Press Esc to cancel the command line.
@@ -160,6 +180,7 @@ difi reads its configuration from ~/.config/difi/config.yaml.
 editor                 editor command (or env vars DIFI_EDITOR, EDITOR, VISUAL)
 ui.theme               colorscheme name (see |difi-themes|)
 ui.line_numbers        line number style (hybrid, relative, absolute, hidden)
+ui.diff_mode           diff layout (unified, split)
 ui.diff_add_bg         hex color override for added line backgrounds
 ui.diff_del_bg         hex color override for deleted line backgrounds
 

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -11,6 +11,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/xguot/difi/internal/config"
+	"github.com/xguot/difi/internal/diffsplit"
 	"github.com/xguot/difi/internal/tree"
 	"github.com/xguot/difi/internal/vcs"
 )
@@ -26,7 +27,7 @@ const (
 )
 
 var ansiRe = regexp.MustCompile("[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))")
-var bgAnsiRe = regexp.MustCompile(`\x1b\[48;2;\d+;\d+;\d+m|\x1b\[4[0-9]m`)
+var bgAnsiRe = regexp.MustCompile(`\x1b\[48;2;\d+;\d+;\d+m|\x1b\[48;5;\d+m|\x1b\[4[0-9]m`)
 
 type StatsMsg struct {
 	Added   int
@@ -56,6 +57,7 @@ type Model struct {
 	diffContent     string
 	diffLines       []string
 	diffHighlighted []string
+	splitRows       []diffsplit.Row
 	diffCursor      int
 	visualMode      bool
 	visualStart     int
@@ -252,8 +254,61 @@ func isDiffContentLine(cleanLine string) bool {
 		strings.HasPrefix(cleanLine, "-")
 }
 
+func (m *Model) splitMode() bool {
+	mode := strings.ToLower(strings.TrimSpace(m.treeDelegate.Config.UI.DiffMode))
+	return mode == "split"
+}
+
+func (m *Model) toggleSplitMode() {
+	if m.splitMode() {
+		m.treeDelegate.Config.UI.DiffMode = "unified"
+	} else {
+		m.treeDelegate.Config.UI.DiffMode = "split"
+	}
+	// Preserve current focus: toggling layout from the tree keeps you in the tree.
+	m.applyDiffModeChange(false)
+}
+
+// applyDiffModeChange rebuilds split state after a diff-mode switch. Because the
+// cursor index means different things in unified vs split layouts, the cursor
+// and any active visual selection are reset to a known-good state. Focus only
+// moves to the diff pane when entering split layout.
+func (m *Model) applyDiffModeChange(focusDiff bool) {
+	m.visualMode = false
+	m.visualStart = 0
+	m.rebuildSplitRows()
+	m.diffCursor = m.snapCursor(0, 1)
+	m.setYOffset(0)
+	if focusDiff {
+		m.focus = FocusDiff
+	}
+	m.updateTreeFocus()
+}
+
+func (m *Model) rebuildSplitRows() {
+	if m.splitMode() {
+		m.splitRows = diffsplit.Build(m.diffLines, m.diffHighlighted)
+	} else {
+		m.splitRows = nil
+	}
+}
+
+func (m *Model) diffLineCount() int {
+	if m.splitMode() {
+		return len(m.splitRows)
+	}
+	return len(m.diffLines)
+}
+
+func (m *Model) cursorRawIdx() int {
+	if m.splitMode() && m.diffCursor >= 0 && m.diffCursor < len(m.splitRows) {
+		return m.splitRows[m.diffCursor].PrimaryRawIdx()
+	}
+	return m.diffCursor
+}
+
 func (m *Model) setYOffset(offset int) {
-	maxOffset := len(m.diffLines) - m.diffViewport.Height
+	maxOffset := m.diffLineCount() - m.diffViewport.Height
 	if maxOffset < 0 {
 		maxOffset = 0
 	}
@@ -269,6 +324,19 @@ func (m *Model) setYOffset(offset int) {
 }
 
 func (m *Model) snapCursor(idx int, dir int) int {
+	if m.splitMode() {
+		if len(m.splitRows) == 0 {
+			return 0
+		}
+		if idx < 0 {
+			idx = 0
+		}
+		if idx >= len(m.splitRows) {
+			idx = len(m.splitRows) - 1
+		}
+		return idx
+	}
+
 	if len(m.diffLines) == 0 {
 		return 0
 	}

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -241,6 +241,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.updateTreeFocus()
 			m.inputBuffer = ""
 
+		case "s":
+			if item, ok := m.fileList.SelectedItem().(tree.TreeItem); ok && !item.IsDir {
+				m.toggleSplitMode()
+				m.handleScrolling()
+			}
+			m.inputBuffer = ""
+
 		case "f":
 			if m.focus == FocusTree {
 				m.flatMode = !m.flatMode
@@ -271,7 +278,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 				line := 0
 				if m.focus == FocusDiff {
-					line = m.vcs.CalculateFileLine(m.diffLines, m.diffCursor)
+					line = m.vcs.CalculateFileLine(m.diffLines, m.cursorRawIdx())
 				} else {
 					line = m.vcs.CalculateFileLine(m.diffLines, 0)
 				}
@@ -360,7 +367,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					target := count - 1
 					m.diffCursor = m.snapCursor(target, 1)
 				} else {
-					m.diffCursor = m.snapCursor(len(m.diffLines)-1, -1)
+					m.diffCursor = m.snapCursor(m.diffLineCount()-1, -1)
 				}
 				m.setYOffset(m.diffCursor - m.diffViewport.Height + 1)
 				m.inputBuffer = ""
@@ -470,6 +477,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.diffHighlighted = hlLines
 		m.currentFileAdded = added
 		m.currentFileDeleted = deleted
+		m.rebuildSplitRows()
 		m.diffCursor = m.snapCursor(0, 1)
 
 	case vcs.EditorFinishedMsg:
@@ -561,7 +569,7 @@ func (m *Model) executeCommand() (bool, tea.Cmd) {
 
 	// :$ — jump to last diff line
 	if cmd == "$" {
-		m.diffCursor = m.snapCursor(len(m.diffLines)-1, -1)
+		m.diffCursor = m.snapCursor(m.diffLineCount()-1, -1)
 		m.centerDiffCursor()
 		return false, nil
 	}
@@ -595,6 +603,12 @@ func (m *Model) executeSet(opt string) {
 		m.treeDelegate.Config.UI.LineNumbers = "absolute"
 	case "hidden":
 		m.treeDelegate.Config.UI.LineNumbers = "hidden"
+	case "split":
+		m.treeDelegate.Config.UI.DiffMode = "split"
+		m.applyDiffModeChange(true)
+	case "unified":
+		m.treeDelegate.Config.UI.DiffMode = "unified"
+		m.applyDiffModeChange(false)
 	}
 }
 
@@ -606,6 +620,7 @@ var setOptionNames = []string{
 	"number", "nonumber", "nu", "nonu",
 	"relativenumber", "norelativenumber", "rnu", "nornu",
 	"hybrid", "relative", "absolute", "hidden",
+	"split", "unified",
 }
 
 // tabComplete handles vim-style tab cycling through matching completions.

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -57,6 +57,12 @@ func (m Model) View() string {
 
 		if ok && selectedItem.IsDir {
 			rightPaneView = m.renderEmptyState(m.diffViewport.Width, contentHeight, "Directory: "+selectedItem.Name)
+		} else if m.splitMode() {
+			rightPaneView = S.DiffStyle.Copy().
+				Width(m.diffViewport.Width).
+				Height(contentHeight).
+				MaxHeight(contentHeight).
+				Render(m.renderSplitDiff(contentHeight))
 		} else {
 			var renderedDiff strings.Builder
 
@@ -127,8 +133,9 @@ func (m Model) View() string {
 				}
 
 				if mode != "hidden" {
+					rawIdx := m.cursorRawIdx()
 					if isCursor && mode == "hybrid" {
-						realLine := m.vcs.CalculateFileLine(m.diffLines, m.diffCursor)
+						realLine := m.vcs.CalculateFileLine(m.diffLines, rawIdx)
 						numStr = fmt.Sprintf("%d", realLine)
 					} else if isCursor && mode == "relative" {
 						numStr = "0"
@@ -206,7 +213,7 @@ func (m Model) View() string {
 				Height(contentHeight).
 				MaxHeight(contentHeight).
 				Render(diffContentStr)
-			}
+		}
 
 		mainContent = lipgloss.JoinHorizontal(lipgloss.Top, treeView, rightPaneView)
 	}
@@ -226,6 +233,9 @@ func (m Model) renderTopBar() string {
 	}
 
 	info := fmt.Sprintf(" %s:%s  %s ➜ %s%s", m.repoName, vcsType, m.currentBranch, m.targetBranch, repoStats)
+	if m.splitMode() {
+		info += "  split"
+	}
 	leftSide := S.TopInfoStyle.Render(info)
 
 	rightSide := ""
@@ -331,6 +341,7 @@ func (m Model) renderHelpDrawer() string {
 
 	edit := lipgloss.JoinVertical(lipgloss.Left,
 		S.HelpTextStyle.Render("e / Enter    Edit file at cursor"),
+		S.HelpTextStyle.Render("s            Toggle split / unified diff (any pane)"),
 		S.HelpTextStyle.Render("V            Visual selection mode"),
 		S.HelpTextStyle.Render("f            Toggle flat tree mode"),
 		S.HelpTextStyle.Render("esc          Cancel visual mode"),
@@ -338,7 +349,7 @@ func (m Model) renderHelpDrawer() string {
 
 	cmds := lipgloss.JoinVertical(lipgloss.Left,
 		S.HelpTextStyle.Render(":colorscheme Switch theme"),
-		S.HelpTextStyle.Render(":set <opt>   Change setting"),
+		S.HelpTextStyle.Render(":set <opt>   Change setting (split/unified)"),
 		S.HelpTextStyle.Render(":w           Refresh diff"),
 		S.HelpTextStyle.Render(":noh         Clear highlight"),
 		S.HelpTextStyle.Render(":<num>  :$   Jump to line"),

--- a/internal/ui/view_split.go
+++ b/internal/ui/view_split.go
@@ -1,0 +1,238 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/xguot/difi/internal/diffsplit"
+)
+
+// splitLineNumWidth matches LineNumberStyle: Width(4) + MarginRight(1).
+const splitLineNumWidth = 5
+
+// splitGutterWidth matches unified diff gutter: "+ │ " / "- │ " / "  │ ".
+const splitGutterWidth = 4
+
+type splitLayout struct {
+	totalW     int
+	leftColW   int
+	rightColW  int
+	leftCodeW  int
+	rightCodeW int
+}
+
+func computeSplitLayout(totalW int, showLineNums bool) splitLayout {
+	if totalW < 3 {
+		totalW = 3
+	}
+	sepW := 1
+	leftColW := (totalW - sepW) / 2
+	rightColW := totalW - sepW - leftColW
+
+	numW := 0
+	if showLineNums {
+		numW = splitLineNumWidth
+	}
+
+	metaW := numW + splitGutterWidth
+
+	return splitLayout{
+		totalW:     totalW,
+		leftColW:   leftColW,
+		rightColW:  rightColW,
+		leftCodeW:  max1(leftColW - metaW),
+		rightCodeW: max1(rightColW - metaW),
+	}
+}
+
+func max1(n int) int {
+	if n < 1 {
+		return 1
+	}
+	return n
+}
+
+func splitGutterStr(kind diffsplit.LineKind, isCursor bool) string {
+	sep := "│"
+	if isCursor {
+		sep = "┃"
+	}
+	switch kind {
+	case diffsplit.KindAdd:
+		return "+ " + sep + " "
+	case diffsplit.KindDel:
+		return "- " + sep + " "
+	default:
+		return "  " + sep + " "
+	}
+}
+
+func (m Model) renderSplitGutter(kind diffsplit.LineKind, isGitTheme bool) string {
+	s := splitGutterStr(kind, false)
+	if isGitTheme {
+		switch kind {
+		case diffsplit.KindAdd:
+			return lipgloss.NewStyle().Foreground(lipgloss.Color("2")).Render(s)
+		case diffsplit.KindDel:
+			return lipgloss.NewStyle().Foreground(lipgloss.Color("1")).Render(s)
+		}
+		return S.DiffCtxGutter.Render(s)
+	}
+	switch kind {
+	case diffsplit.KindAdd:
+		return S.DiffAddGutter.Render(s)
+	case diffsplit.KindDel:
+		return S.DiffDelGutter.Render(s)
+	default:
+		return S.DiffCtxGutter.Render(s)
+	}
+}
+
+func splitCursorStyle(kind diffsplit.LineKind) lipgloss.Style {
+	switch kind {
+	case diffsplit.KindAdd:
+		return S.CursorAddStyle
+	case diffsplit.KindDel:
+		return S.CursorDelStyle
+	default:
+		return S.CursorNormalStyle
+	}
+}
+
+func padVisible(s string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	n := lipgloss.Width(s)
+	if n > width {
+		return ansi.Truncate(s, width, "")
+	}
+	if n < width {
+		return s + strings.Repeat(" ", width-n)
+	}
+	return s
+}
+
+func expandTabs(s string) string {
+	return strings.ReplaceAll(s, "\t", "    ")
+}
+
+func stripHighlightBg(s string) string {
+	return bgAnsiRe.ReplaceAllString(s, "")
+}
+
+// renderSplitCode renders the code portion matching unified view: syntax
+// highlighting by default (git theme uses colored plain text for +/- lines).
+func (m Model) renderSplitCode(side diffsplit.Side, codeW int, isGitTheme bool) string {
+	content := expandTabs(side.Content)
+
+	if isGitTheme && (side.Kind == diffsplit.KindAdd || side.Kind == diffsplit.KindDel) {
+		truncated := padVisible(ansi.Truncate(content, codeW, ""), codeW)
+		if side.Kind == diffsplit.KindAdd {
+			return lipgloss.NewStyle().Foreground(lipgloss.Color("2")).Render(truncated)
+		}
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("1")).Render(truncated)
+	}
+
+	hl := side.Highlighted
+	if hl == "" {
+		hl = side.Content
+	}
+	hl = stripHighlightBg(expandTabs(hl))
+	return padVisible(ansi.Truncate(hl, codeW, ""), codeW)
+}
+
+func (m Model) renderSplitDiff(contentHeight int) string {
+	layout := computeSplitLayout(m.diffViewport.Width, m.treeDelegate.Config.UI.LineNumbers != "hidden")
+	isGitTheme := m.treeDelegate.Config.UI.Theme == "git"
+	showLineNums := m.treeDelegate.Config.UI.LineNumbers != "hidden"
+	t := ActiveTheme()
+
+	sepStyle := lipgloss.NewStyle().Foreground(t.Border)
+	sepCursorStyle := lipgloss.NewStyle().Foreground(t.FocusedBorder).Bold(true)
+
+	var rendered strings.Builder
+
+	start := m.diffViewport.YOffset
+	end := start + contentHeight
+	if end > len(m.splitRows) {
+		end = len(m.splitRows)
+	}
+
+	for i := start; i < end; i++ {
+		row := m.splitRows[i]
+		isCursor := false
+		if m.focus == FocusDiff {
+			if m.visualMode {
+				minIdx, maxIdx := m.visualStart, m.diffCursor
+				if minIdx > maxIdx {
+					minIdx, maxIdx = maxIdx, minIdx
+				}
+				isCursor = (i >= minIdx && i <= maxIdx)
+			} else {
+				isCursor = (i == m.diffCursor)
+			}
+		}
+
+		sep := sepStyle.Render("│")
+		if isCursor {
+			sep = sepCursorStyle.Render("│")
+		}
+
+		left := m.renderSplitCell(row.Left, layout.leftColW, layout.leftCodeW, showLineNums, isCursor, isGitTheme)
+		right := m.renderSplitCell(row.Right, layout.rightColW, layout.rightCodeW, showLineNums, isCursor, isGitTheme)
+
+		line := left + sep + right
+		line = padVisible(line, layout.totalW)
+		rendered.WriteString(line + "\n")
+	}
+
+	return rendered.String()
+}
+
+func (m Model) renderSplitCell(side diffsplit.Side, colW, codeW int, showLineNums, isCursor, isGitTheme bool) string {
+	if colW <= 0 {
+		return ""
+	}
+	if codeW < 0 {
+		codeW = 0
+	}
+
+	lineNum := ""
+	if showLineNums {
+		numStr := ""
+		if side.LineNo > 0 {
+			numStr = fmt.Sprintf("%d", side.LineNo)
+		}
+		lineNum = S.LineNumberStyle.Render(numStr)
+	}
+
+	gutterKind := side.Kind
+	if gutterKind == diffsplit.KindEmpty {
+		gutterKind = diffsplit.KindContext
+	}
+
+	gutterAndCodeW := splitGutterWidth + codeW
+
+	// Cursor row: gutter + plain code highlighted together (same as unified view).
+	if isCursor && side.Kind != diffsplit.KindEmpty {
+		content := padVisible(ansi.Truncate(expandTabs(side.Content), codeW, ""), codeW)
+		combined := splitGutterStr(gutterKind, true) + content
+		combined = padVisible(combined, gutterAndCodeW)
+		combined = splitCursorStyle(gutterKind).Copy().Width(gutterAndCodeW).Render(combined)
+		return padVisible(lineNum+combined, colW)
+	}
+
+	var codeCell string
+	if side.Kind == diffsplit.KindEmpty {
+		codeCell = strings.Repeat(" ", codeW)
+	} else {
+		codeCell = m.renderSplitCode(side, codeW, isGitTheme)
+	}
+
+	gutter := m.renderSplitGutter(gutterKind, isGitTheme)
+	return padVisible(lineNum+gutter+codeCell, colW)
+}

--- a/internal/ui/view_split_test.go
+++ b/internal/ui/view_split_test.go
@@ -1,0 +1,74 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+
+	"github.com/xguot/difi/internal/config"
+	"github.com/xguot/difi/internal/diffsplit"
+)
+
+func initTestStyles(t *testing.T) {
+	t.Helper()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	cfg := config.Config{UI: config.UIConfig{Theme: "nord"}}
+	InitStyles(cfg)
+}
+
+func TestComputeSplitLayout(t *testing.T) {
+	layout := computeSplitLayout(81, true)
+	if layout.leftColW+1+layout.rightColW != 81 {
+		t.Fatalf("columns don't sum to total: %d + 1 + %d != 81", layout.leftColW, layout.rightColW)
+	}
+	if layout.leftCodeW != layout.leftColW-splitLineNumWidth-splitGutterWidth {
+		t.Errorf("leftCodeW = %d, want %d", layout.leftCodeW, layout.leftColW-splitLineNumWidth-splitGutterWidth)
+	}
+
+	noNums := computeSplitLayout(80, false)
+	if noNums.leftCodeW != noNums.leftColW-splitGutterWidth {
+		t.Errorf("without line nums, leftCodeW should equal leftColW minus gutter")
+	}
+}
+
+func TestPadVisible(t *testing.T) {
+	if got := padVisible("abc", 6); got != "abc   " {
+		t.Errorf("padVisible short = %q", got)
+	}
+	if got := padVisible("hello world", 5); lipgloss.Width(got) != 5 {
+		t.Errorf("padVisible truncate width = %d, want 5", lipgloss.Width(got))
+	}
+}
+
+func TestSplitGutterStr(t *testing.T) {
+	if got := splitGutterStr(diffsplit.KindAdd, false); got != "+ │ " {
+		t.Errorf("add gutter = %q", got)
+	}
+	if got := splitGutterStr(diffsplit.KindDel, true); got != "- ┃ " {
+		t.Errorf("del cursor gutter = %q", got)
+	}
+	if got := splitGutterStr(diffsplit.KindContext, false); got != "  │ " {
+		t.Errorf("ctx gutter = %q", got)
+	}
+}
+
+func TestExpandTabs(t *testing.T) {
+	if got := expandTabs("a\tb"); got != "a    b" {
+		t.Errorf("expandTabs = %q", got)
+	}
+}
+
+func TestRenderSplitCode_noBackgroundByDefault(t *testing.T) {
+	initTestStyles(t)
+	m := Model{}
+	side := diffsplit.Side{
+		Kind:    diffsplit.KindAdd,
+		Content: `fmt.Println("new")`,
+	}
+	got := m.renderSplitCode(side, 40, false)
+	if strings.Contains(got, "\x1b[48") {
+		t.Errorf("default add line should not have background highlight: %q", got)
+	}
+}

--- a/internal/vcs/interface_test.go
+++ b/internal/vcs/interface_test.go
@@ -106,12 +106,12 @@ func TestVCSInterfaceConsistency(t *testing.T) {
 			})
 
 			t.Run("CalculateFileLine", func(t *testing.T) {
-				line := vcs.CalculateFileLine("", 0)
+				line := vcs.CalculateFileLine(nil, 0)
 				if line != 1 && line != 0 {
-					t.Errorf("%s CalculateFileLine('', 0) should return 1 or 0, got %d", impl.name, line)
+					t.Errorf("%s CalculateFileLine(nil, 0) should return 1 or 0, got %d", impl.name, line)
 				}
 
-				line = vcs.CalculateFileLine("single line", 10)
+				line = vcs.CalculateFileLine([]string{"single line"}, 10)
 				if line < 0 {
 					t.Errorf("%s CalculateFileLine with out-of-bounds index should not return negative, got %d", impl.name, line)
 				}

--- a/man/man1/difi.1.scd
+++ b/man/man1/difi.1.scd
@@ -89,6 +89,8 @@ left or right pane directly.
 :  Center cursor / top / bottom scroll
 |  _e_, _Enter_
 :  Edit file at the cursor line
+|  _s_
+:  Toggle split / unified diff view
 |  _V_
 :  Toggle visual selection mode
 |  _f_
@@ -181,6 +183,10 @@ values. Press _Esc_ to cancel.
 :  Absolute mode
 |  _hidden_
 :  No line numbers
+|  _split_
+:  Side-by-side diff layout
+|  _unified_
+:  Unified diff layout (default)
 
 # EDITING
 
@@ -212,6 +218,9 @@ file does not exist, sensible defaults are used.
 |  _ui.line_numbers_
 :  _hybrid_
 :  Line number style (_hybrid_, _relative_, _absolute_, _hidden_)
+|  _ui.diff_mode_
+:  _unified_
+:  Diff layout (_unified_ or _split_)
 |  _ui.diff_add_bg_
 :  _""_
 :  Hex color for added line backgrounds


### PR DESCRIPTION
## Summary

- Add a **split diff layout** (GitHub-style side-by-side: old left, new right) alongside the existing unified view
- Toggle with `s`, `:set split` / `:set unified`, or `ui.diff_mode` in `~/.config/difi/config.yaml`
- New `internal/diffsplit` package pairs add/delete lines and maps line numbers for editor navigation
- Split rendering supports line numbers, syntax highlighting, cursor highlighting, and visual selection
- Visual selection resets when switching layouts to avoid stale index mismatches between unified and split row indices
- Pressing `s` from the file tree toggles layout without stealing focus from the tree pane

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] Open a changed file and press `s` to toggle split/unified
- [x] Verify side-by-side pairing for add/delete hunks (including pure adds and pure deletes)
- [x] Verify `:set split` and `:set unified` work from command mode
- [x] Verify `ui.diff_mode: "split"` in config sets the default layout
- [x] Verify visual mode (`V`) clears correctly when toggling layout

## Screenshot

<img width="1906" height="210" alt="image" src="https://github.com/user-attachments/assets/43eb6334-8ca3-4d5b-936f-df01f96150f8" />


