### PR TITLE
Save lastCfg in InitStyles so ActiveTheme respects configured theme at startup

### DIFF
--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -49,6 +49,9 @@ var S *Styles
 
 // InitStyles builds all UI styles from the selected theme and user config overrides.
 func InitStyles(cfg config.Config) {
+	copyCfg := cfg
+	lastCfg = &copyCfg
+
 	t := GetTheme(cfg.UI.Theme)
 	if t == nil {
 		t = nord
@@ -222,7 +225,5 @@ func lastConfig() (config.Config, bool) {
 
 // ReinitStyles rebuilds styles from a new config (used after :colorscheme).
 func ReinitStyles(cfg config.Config) {
-	copyCfg := cfg
-	lastCfg = &copyCfg
 	InitStyles(cfg)
 }


### PR DESCRIPTION
Fixes #51.

InitStyles was building S from the configured theme but never setting lastCfg, so ActiveTheme() always fell back to Nord on startup. Only the interactive :theme command worked because ReinitStyles did save lastCfg.

Move the save into InitStyles so both paths are covered, and simplify ReinitStyles to just delegate.
